### PR TITLE
Extend JOIN statement to include dataset_name

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -94,7 +94,7 @@ def load_event_all_stats(db: Session, event_id: str):
             FROM event_metadata 
             JOIN sample_metadata USING (event_id)
             JOIN datasets USING (dataset_name)
-            JOIN stacks_runs ON stacks_runs.stacks_run_name = datasets.r80
+            JOIN stacks_runs ON (stacks_runs.stacks_run_name = datasets.r80 AND stacks_runs.dataset_name = datasets.dataset_name)
             JOIN populations_sumstats_summary_all_positions USING (stacks_run_id)
             WHERE event_metadata.event_id = :event_id
             """


### PR DESCRIPTION
load_all_event_stats was returning multiple different run_name for different species because it was not also conditioning on dataset_name.